### PR TITLE
Updated the valid application names in pipe sync

### DIFF
--- a/default/profiles/orca-local.yml
+++ b/default/profiles/orca-local.yml
@@ -16,7 +16,7 @@ job:
         credentials: default
         description: Update git with pipelines in Spinnaker
         account: default
-        application: gitopsHalyard.pipelinePromotion
+        application: sampleapp
         type: pipelineSyncToGit
         waitForCompletion: true
         parameters:
@@ -89,7 +89,7 @@ job:
         credentials: default
         description: Sync Spinnaker pipelines from git
         account: default
-        application: gitopsHalyard.pipelinePromotion
+        application: sampleapp
         type: pipelineSyncToSpinnaker
         waitForCompletion: true
         parameters:


### PR DESCRIPTION
Removed the old application name gitopsHalyard.pipelinePromotion where it is not a valid application, it should be the existing app name that is in the spinnaker. Orca-local will take the app as ref a will do functionality