### PR TITLE
SSH key configuration for external accounts to 3.10

### DIFF
--- a/default/profiles/spinnakerconfig.yml.ssh
+++ b/default/profiles/spinnakerconfig.yml.ssh
@@ -1,3 +1,5 @@
+encrypt:
+  key: Q7udUkHPuA3VnNlOtksSgQ
 spring:
   profiles:
     include: git

--- a/default/profiles/spinnakerconfig.yml.ssh
+++ b/default/profiles/spinnakerconfig.yml.ssh
@@ -1,0 +1,12 @@
+spring:
+  profiles:
+    include: git
+  cloud:
+    config:
+      server:
+        git:
+          uri: DYNAMIC_ACCOUNTS_REPO
+          basedir: /tmp/config-repo
+          strictHostKeyChecking: false
+          ignoreLocalSshSettings: true
+          privateKey: |


### PR DESCRIPTION
added the spinnakerconfig.yml.ssh it can be handled via init container when the Gitops halyard is enabled with SSH