### PR TITLE
Gitea supported pipline-promotion configuration

### DIFF
--- a/MISC/PP/git-token-secret.yaml
+++ b/MISC/PP/git-token-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+stringData:
+  # Git token to access repo where pipeline stuff is stored
+  git_secret_token: GITEA_TOKEN
+  git_secret_sshkey: ""
+  git_pr_token: token
+kind: Secret
+metadata:
+  name: git-token
+type: Opaque

--- a/MISC/PP/pipe-promot-config-cm.yaml
+++ b/MISC/PP/pipe-promot-config-cm.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+  repo.properties: |
+    #properties file for pipeline promotion scripts
+
+    # Common Stuff
+    repo_type=gitea
+    repo_name=gitea-standard-repo
+    root_folder=pipeline/
+    #S3 Specific
+    export AWS_ACCESS_KEY_ID=access_key
+    export AWS_SECRET_ACCESS_KEY=secret_key
+
+    #git mandatory patameters
+    git_url=GITEA_URL
+    git_project=GITEA_USER
+    git_user=GITEA_USER
+    git_branch=master
+    #git_password=
+    #API
+    git_api_url=https://api.github.com/repos  # bitbucket
+
+    #Auto PR requirements
+    merge_branch=false
+    auto_merge=false
+    git_approve_user=approver_user
+    target_branch=master
+
+    #optional
+    #git_user_email=krish@company.com
+
+    #delete pipeLine
+    delete_on_sync_spin=
+    delete_on_sync_repo=
+    #git_approve_user_password=
+    #git_secret_sshkey=
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: pipe-promot-config


### PR DESCRIPTION
It has two templates
1. secret called git-token value will be replaced the gitea token and create secret in init container
2. configamp called pipe-promot-config  values will be replaced like gitea url, project and user and create a configmap